### PR TITLE
Higher precision timing labels and better browser compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /*global window, global*/
 var util = require("util")
 var assert = require("assert")
+var now = require("performance-now")
 
 var slice = Array.prototype.slice
 var console
@@ -53,7 +54,7 @@ function error() {
 }
 
 function time(label) {
-    times[label] = Date.now()
+    times[label] = now()
 }
 
 function timeEnd(label) {
@@ -62,8 +63,8 @@ function timeEnd(label) {
         throw new Error("No such label: " + label)
     }
 
-    var duration = Date.now() - time
-    console.log(label + ": " + duration + "ms")
+    var duration = now() - time
+    console.log(label + ": " + duration.toFixed(2) + "ms")
 }
 
 function trace() {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "url": "https://github.com/Raynos/console-browserify/issues",
     "email": "raynos2@gmail.com"
   },
-  "dependencies": {},
+  "dependencies": {
+    "performance-now": "~0.1.3"
+  },
   "devDependencies": {
     "tape": "~2.3.0",
     "jsonify": "0.0.0"


### PR DESCRIPTION
- Use performance-now module which picks the higest precision, most performant
  timing option avilable:
  performance.now > process.hrtime > Date.now > new Date().getTime()
  Timing results are now printed with two decimal places (there doesn't seem to
  be any spec available for the console object; FF prints two, while Safari and
  Chrome print three)
- Date.now is not available in IE<9 or in older versions of Safari and Opera, so
  this change has the added benefit of providing fallbacks for these browsers:
  http://kangax.github.io/es5-compat-table/#Date.now
