### PR TITLE
Make `assert` more spec-compliant

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,6 @@ function dir(object) {
 
 function assert(expression) {
     if (!expression) {
-        console.error.apply(null, concat.call(["Assertion failed:"], arguments.length > 1 ? slice.call(arguments, 1) : "console.assert"))
+        console.error.apply(null, arguments.length > 1 ? concat.call(["Assertion failed:"], slice.call(arguments, 1)) : ["Assertion failed"])
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 /*global window, global*/
 var util = require("util")
-var assert = require("assert")
 function now() { return new Date().getTime() }
 
 var slice = Array.prototype.slice
+var concat = Array.prototype.concat
 var console
 var times = {}
 
@@ -24,7 +24,7 @@ var functions = [
     [timeEnd, "timeEnd"],
     [trace, "trace"],
     [dir, "dir"],
-    [consoleAssert, "assert"]
+    [assert, "assert"]
 ]
 
 for (var i = 0; i < functions.length; i++) {
@@ -79,9 +79,8 @@ function dir(object) {
     console.log(util.inspect(object) + "\n")
 }
 
-function consoleAssert(expression) {
+function assert(expression) {
     if (!expression) {
-        var arr = slice.call(arguments, 1)
-        assert.ok(false, util.format.apply(null, arr))
+        console.error.apply(null, concat.call(["Assertion failed:"], arguments.length > 1 ? slice.call(arguments, 1) : "console.assert"))
     }
 }

--- a/index.js
+++ b/index.js
@@ -81,6 +81,6 @@ function dir(object) {
 
 function assert(expression) {
     if (!expression) {
-        console.error.apply(null, arguments.length > 1 ? concat.call(["Assertion failed:"], slice.call(arguments, 1)) : ["Assertion failed"])
+        console.error.apply(null, concat.call(["Assertion failed:"], slice.call(arguments, 1)))
     }
 }


### PR DESCRIPTION
Current polyfill:

```js
console.assert(false)
//=> Uncaught AssertionError [ERR_ASSERTION]: false == true

console.assert(false, 1, 2, 3)
//=> Uncaught AssertionError [ERR_ASSERTION]: 1
```

Normal behaviour:

```js
console.assert(false)
//=> Assertion failed

console.assert(false, 1, 2, 3)
//=> Assertion failed: 1 2 3
```

New behaviour:

```js
console.assert(false)
//=> Assertion failed

console.assert(false, 1, 2, 3)
//=> Assertion failed: 1 2 3
```

Fixes https://github.com/browserify/console-browserify/issues/5
Also fixes https://github.com/Richienb/node-polyfill-webpack-plugin/issues/18